### PR TITLE
chore: Added snippets for easier imports and docs

### DIFF
--- a/.vscode/cpsc585.code-snippets
+++ b/.vscode/cpsc585.code-snippets
@@ -1,0 +1,42 @@
+{
+  "Header Comment":{
+    "description": "Header comment for a file, with auto-generated information.",
+    "body": [ "/**",
+              " * Date created: $CURRENT_DATE/$CURRENT_MONTH_NAME_SHORT/$CURRENT_YEAR",
+              " * Project name: TBD",
+              " * Course: CPSC 585 Games Programming",
+              " * Semester: Winter 2023",
+              " * Course instructor: Dr. Ben Stephenson",
+              " * File author: ${1:}",
+              " */",
+              "${0:}"],
+              "prefix": "fhed",
+              "scope": "c,cpp,objective-c,objective-cpp"
+  },
+  "C++ Class":{
+    "description": "Creates a new C++ class, with standard imports.",
+    "body": [
+      "#include <iostream>",
+      "",
+      "using namespace std",
+      "",
+      "class ${1:ClassName} {",
+      "public:",
+      "",
+      "protected:",
+      "",
+      "private:",
+      "",
+      "};${0:}"],
+      "prefix": "cppclass"
+  },
+  "OpenGL Includes":{
+    "description": "Standard imports used in OpenGL files",
+    "prefix": "opengl",
+    "body": [ "#include <glad/glad.h>",
+              "#include <GLFW/glfw3.h>",
+              "${0:}"]
+
+  }
+
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
  {
-    "cmake.generator": "Visual Studio 16 2019"
+   "cmake.generator": "Visual Studio 16 2019",
+   "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+   "files.associations": {
+    "*.vert":"objective-c",
+    "*.frag":"objective-c"
+   }
  }


### PR DESCRIPTION
- Added vscode snippets to auto-make header comments for created files, including the name of file author (triggered by typing "fhed") 
- Added vscode snippet to auto-make a template for a C++ class (triggered by typing "cclass")
- Added vscode snippet to auto-make includes for openGL (triggered by typing "opengl")
- Updated vscode settings to interpret *.vert and *.frag files as objective-c, to allow semantic highlighting to work (can be overridden by users' personal settings)