### PR TITLE
Yas win/lose logic

### DIFF
--- a/DustRiders/DustRiders/Camera.cpp
+++ b/DustRiders/DustRiders/Camera.cpp
@@ -19,6 +19,7 @@ void Camera::setFocusEntity(Entity* newFocus) {
 glm::mat4 Camera::getView() {
 	glm::vec3 eye = getPos();
 	glm::vec3 at = focusEntity->transform->position + focusOffset;
+	at.x = 0;
 	glm::vec3 up = glm::vec3(0.0f, 1.0f, 0.0f);
 
 	return glm::lookAt(eye, at, up);
@@ -26,6 +27,7 @@ glm::mat4 Camera::getView() {
 
 glm::vec3 Camera::getPos() {
 	glm::vec3 position = focusEntity->transform->position;
+	position.x = 0;
 	glm::vec3 direction{ 0.0f, 0.0f, -1.0f };
 	glm::vec3 up = glm::vec3(0.0f, 1.0f, 0.0f);
 

--- a/DustRiders/DustRiders/ECS.h
+++ b/DustRiders/DustRiders/ECS.h
@@ -24,6 +24,7 @@ public:
 
 	std::vector<Entity*> getAll();
 	std::vector<std::string> getKeys();
+	void erase(std::string s) { map.erase(s); }
 
 	static EntityComponentSystem* getInstance();
 

--- a/DustRiders/DustRiders/Overlay.cpp
+++ b/DustRiders/DustRiders/Overlay.cpp
@@ -255,6 +255,66 @@ void Overlay::RenderMenu(int windowHeight, int windowWidth)
 	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }
 
+void Overlay::RenderWin(int windowHeight, int windowWidth)
+{
+	bool isKeyboard = !JoystickHandler::getFirstJS().isPseudo();
+
+	ImGui_ImplOpenGL3_NewFrame();
+	ImGui_ImplGlfw_NewFrame();
+	ImGui::NewFrame();
+	// Putting the text-containing window in the top-left of the screen.
+
+	// Setting flags
+	ImGuiWindowFlags textWindowFlags =
+		ImGuiWindowFlags_NoMove |						// text "window" should not move
+		ImGuiWindowFlags_NoResize |					// should not resize
+		ImGuiWindowFlags_NoCollapse |				// should not collapse
+		ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
+		ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
+		ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
+		ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
+		ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
+
+	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.75, windowHeight / 2));
+	ImGui::Begin("DustRiderTitle", (bool*)0, textWindowFlags);
+	ImGui::SetWindowFontScale(5.0f);
+	ImGui::Text("You Win!");
+	ImGui::End();
+
+	ImGui::Render(); // Render the ImGui window
+	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+}
+
+void Overlay::RenderLoss(int windowHeight, int windowWidth)
+{
+	bool isKeyboard = !JoystickHandler::getFirstJS().isPseudo();
+
+	ImGui_ImplOpenGL3_NewFrame();
+	ImGui_ImplGlfw_NewFrame();
+	ImGui::NewFrame();
+	// Putting the text-containing window in the top-left of the screen.
+
+	// Setting flags
+	ImGuiWindowFlags textWindowFlags =
+		ImGuiWindowFlags_NoMove |						// text "window" should not move
+		ImGuiWindowFlags_NoResize |					// should not resize
+		ImGuiWindowFlags_NoCollapse |				// should not collapse
+		ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
+		ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
+		ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
+		ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
+		ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
+
+	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.75, windowHeight / 2));
+	ImGui::Begin("DustRiderTitle", (bool*)0, textWindowFlags);
+	ImGui::SetWindowFontScale(5.0f);
+	ImGui::Text("You Lose!");
+	ImGui::End();
+
+	ImGui::Render(); // Render the ImGui window
+	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+}
+
 void Overlay::Cleanup()
 {
 	ImGui_ImplOpenGL3_Shutdown();

--- a/DustRiders/DustRiders/Overlay.h
+++ b/DustRiders/DustRiders/Overlay.h
@@ -23,5 +23,7 @@ public:
 	void RenderOverlay(StateHandler::GameState, std::vector<Entity*>);
 	void RenderMenu(int windowHeight, int windowWidth);
 	void RenderPause(int windowHeight, int windowWidth);
+	void RenderWin(int windowHeight, int windowWidth);
+	void RenderLoss(int windowHeight, int windowWidth);
 	void Cleanup();
 };

--- a/DustRiders/DustRiders/StateHandler.h
+++ b/DustRiders/DustRiders/StateHandler.h
@@ -15,11 +15,13 @@ public:
   public:
     enum State
     {
-      Exit = -1,
-      NotStarted = 0,
-      Playing = 1,
-      StartMenu = 2,
-      PauseMenu = 3
+        Exit = -1,
+        NotStarted = 0,
+        Playing = 1,
+        StartMenu = 2,
+        PauseMenu = 3,
+        GameWon = 4,
+        GameLost = 5
     };
 
     operator int() { return static_cast<int>(this->state); }


### PR DESCRIPTION
- updated the camera so that is always stays at x = 0
- Camera follows the car that is first based on z positions
- Vehicle are eliminated when they get off the screen
- the player wins when they are the last one standing. They lose if they are eliminated

The Win/Lose screens don't allow interaction (to exit the application with 'x'). Not sure why but it's prolly an easy fix