### PR TITLE
State Cleanup and Tuning

### DIFF
--- a/DustRiders/DustRiders/AIVehicle.cpp
+++ b/DustRiders/DustRiders/AIVehicle.cpp
@@ -1,42 +1,44 @@
 #include "AIVehicle.h"
 
 AIVehicle::AIVehicle(std::string name,
-	Transform* t,
-	Model* m,
-	ShaderProgram* sp,
-	glm::vec3 s,
-	PhysicsProvider* pp,
-	PxVec3 pos,
-	unsigned int matIdx,
-	NavMesh* navMesh) : Vehicle(name, t, m, sp, s, pp, pos, matIdx)
+										 Transform *t,
+										 Model *m,
+										 ShaderProgram *sp,
+										 glm::vec3 s,
+										 PhysicsProvider *pp,
+										 PxVec3 pos,
+										 unsigned int matIdx,
+										 NavMesh *navMesh) : Vehicle(name, t, m, sp, s, pp, pos, matIdx)
 {
-	//this->aiJS = new Joystick(-1000, true);
+	// this->aiJS = new Joystick(-1000, true);
 	this->pathfinder = new Pathfinder(navMesh);
 }
 
-AIVehicle::~AIVehicle() {
-	//delete this->aiJS;
+AIVehicle::~AIVehicle()
+{
+	// delete this->aiJS;
 	delete this->pathfinder;
 }
 
-bool AIVehicle::isClose(glm::vec3 a, glm::vec3 b) {
+bool AIVehicle::isClose(glm::vec3 a, glm::vec3 b)
+{
 	auto threshold = 10;
 
 	if (abs(b.x - a.x) < threshold &&
-		abs(b.y - a.y) < threshold &&
-		abs(b.z - a.z) < threshold)
+			abs(b.y - a.y) < threshold &&
+			abs(b.z - a.z) < threshold)
 		return true;
 	return false;
 }
 
-void AIVehicle::handlePathfind() {
+void AIVehicle::handlePathfind()
+{
 	dest = this->path.front();
 
 	glm::quat rotation = transform->rotation;
 	glm::mat4 rotationM = glm::toMat4(rotation);
 	auto vanHeadingTemp = glm::vec3(rotationM * glm::vec4(0.f, 0.f, -1.f, 1.f));
 	PxVec3 vanHeading = PxVec3(vanHeadingTemp.x, vanHeadingTemp.y, vanHeadingTemp.z);
-
 
 	// Get vehicle position
 	physx::PxVec3 pos = gVehicle.mPhysXState.physxActor.rigidBody->getGlobalPose().p;
@@ -70,26 +72,29 @@ void AIVehicle::handlePathfind() {
 		}
 	}
 
-	auto accel = (double)std::rand() / RAND_MAX * 0.5 + 0.2;
+	auto accel = (double)std::rand() / RAND_MAX * 0.5;
 	gVehicle.mCommandState.throttle = accel;
 
-	if (isClose(transform->position, dest) && this->path.size() > 1) {
+	if (isClose(transform->position, dest) && this->path.size() > 1)
+	{
 		this->path.erase(this->path.begin());
 	}
-	if (this->path.size() < 2) {
+	if (this->path.size() < 2)
+	{
 		gVehicle.mCommandState.steer = 0.f;
 	}
 }
 
-void AIVehicle::stepPhysics(double timeStep) {
+void AIVehicle::stepPhysics(double timeStep)
+{
 	handlePathfind();
 
-	//float axisThreshold = 0.15f;
-	//const float *analogs = this->aiJS->getAnalogs();
+	// float axisThreshold = 0.15f;
+	// const float *analogs = this->aiJS->getAnalogs();
 
-	//gVehicle.mCommandState.nbBrakes = 1;
+	// gVehicle.mCommandState.nbBrakes = 1;
 
-	//if (aiJS->getButton(Xbox::Button::XBOX_A))
+	// if (aiJS->getButton(Xbox::Button::XBOX_A))
 	//{
 
 	//	std::cout << "Weapon Fired" << std::endl;
@@ -97,38 +102,38 @@ void AIVehicle::stepPhysics(double timeStep) {
 	//		aiJS->releaseEnter();
 	//}
 
-	//if (aiJS->getButton(Xbox::Button::XBOX_UP))
+	// if (aiJS->getButton(Xbox::Button::XBOX_UP))
 	//{
 	//	if (aiJS->isPseudo())
 	//	{
 	//		aiJS->releaseR();
 	//	}
-	//}
+	// }
 
-	//float currentSpeed = gVehicle.mBaseState.tireSpeedStates->speedStates[0];
-	//physx::vehicle2::PxVehicleDirectDriveTransmissionCommandState::Enum gearState = gVehicle.mTransmissionCommandState.gear;
-	//gVehicle.mTransmissionCommandState.gear = gearState;
+	// float currentSpeed = gVehicle.mBaseState.tireSpeedStates->speedStates[0];
+	// physx::vehicle2::PxVehicleDirectDriveTransmissionCommandState::Enum gearState = gVehicle.mTransmissionCommandState.gear;
+	// gVehicle.mTransmissionCommandState.gear = gearState;
 
 	//// By default, no throttle and turn on the brakes to slow down (and stop) the vehicle
-	//float throttle = 0.f;
-	//int brake = 1;
+	// float throttle = 0.f;
+	// int brake = 1;
 
-	//if (aiJS->getButtonRaw(Xbox::Button::XBOX_LB))
+	// if (aiJS->getButtonRaw(Xbox::Button::XBOX_LB))
 	//{
 	//	gVehicle.mTransmissionCommandState.gear = gVehicle.mTransmissionCommandState.eREVERSE;
-	//}
-	//else
+	// }
+	// else
 	//{
 	//	gVehicle.mTransmissionCommandState.gear = gVehicle.mTransmissionCommandState.eFORWARD;
-	//}
+	// }
 
-	//throttle = analogs[Xbox::Analog::XBOX_R_TRIGGER] + 1.f;
-	//throttle /= 2.f;
-	//brake = (int)(analogs[Xbox::Analog::XBOX_L_TRIGGER] > -1.f);
+	// throttle = analogs[Xbox::Analog::XBOX_R_TRIGGER] + 1.f;
+	// throttle /= 2.f;
+	// brake = (int)(analogs[Xbox::Analog::XBOX_L_TRIGGER] > -1.f);
 
-	//gVehicle.mCommandState.throttle = throttle;
-	//gVehicle.mCommandState.brakes[0] = brake;
+	// gVehicle.mCommandState.throttle = throttle;
+	// gVehicle.mCommandState.brakes[0] = brake;
 
-	//gVehicle.mCommandState.steer = -1.f * analogs[Xbox::Analog::XBOX_L_XAXIS]; // Need to flip the direction of the input
+	// gVehicle.mCommandState.steer = -1.f * analogs[Xbox::Analog::XBOX_L_XAXIS]; // Need to flip the direction of the input
 	gVehicle.step(timeStep, gVehicleSimulationContext);
 }

--- a/DustRiders/DustRiders/Entity.h
+++ b/DustRiders/DustRiders/Entity.h
@@ -9,19 +9,16 @@
 class Entity
 {
 public:
-	Entity(std::string n, Transform* t, Model *m, ShaderProgram *sp, glm::vec3 s, unsigned int matInt=0)
-		: name(n)
-		, transform(t)
-		, model(m)
-		, shaderProgram(sp)
-		, scale(s)
-		, useMatInt(matInt)
-	{}
+	Entity(std::string n, Transform *t, Model *m, ShaderProgram *sp, glm::vec3 s, unsigned int matInt = 0)
+			: name(n), transform(t), model(m), shaderProgram(sp), scale(s), useMatInt(matInt), shouldRender(true)
+	{
+	}
 
-	virtual ~Entity() {};
+	virtual ~Entity(){};
 
 	std::string name;
 	Transform *transform;
+	bool shouldRender;
 
 	Model *model;
 	ShaderProgram *shaderProgram;
@@ -30,7 +27,8 @@ public:
 	Texture *texture;
 	unsigned int useMatInt;
 
-	operator std::string() {
+	operator std::string()
+	{
 		std::string result;
 
 		result.append(name + " ");

--- a/DustRiders/DustRiders/InputHandler.h
+++ b/DustRiders/DustRiders/InputHandler.h
@@ -188,7 +188,7 @@ public:
 	void pressW()
 	{
 		if (pseudo)
-			analogs[Xbox::Analog::XBOX_R_TRIGGER] = 1.f;
+			analogs[Xbox::Analog::XBOX_R_TRIGGER] = 0.5f;
 	}
 	void releaseW()
 	{

--- a/DustRiders/DustRiders/InputHandler.h
+++ b/DustRiders/DustRiders/InputHandler.h
@@ -92,7 +92,7 @@ class Joystick
 {
 public:
 	Joystick(int jsID) : jsID(jsID), pseudo(false) {}
-	Joystick() : jsID(jsID), pseudo(pseudo)
+	Joystick() : jsID(-1), pseudo(true)
 	{
 		for (int i = 0; i < 14; i++)
 		{

--- a/DustRiders/DustRiders/LogWriter.h
+++ b/DustRiders/DustRiders/LogWriter.h
@@ -9,25 +9,28 @@ using namespace std;
 class LogWriter
 {
 public:
-  LogWriter(string logFileName = "latest_output.log") : logFileName(logFileName), firstWriting(true) {}
+  LogWriter(string logFileName = "latest_output.log") {}
 
-  void log(string logMessage)
+  static void log(string logMessage)
   {
     if (firstWriting)
     {
-      logFile.open(logFileName);
+      LogWriter::logFile.open(LogWriter::logFileName);
+      LogWriter::firstWriting = false;
     }
     else
     {
-      logFile.open(logFileName, std::ios_base::app);
+      LogWriter::logFile.open(LogWriter::logFileName, std::ios_base::app);
     }
-    logFile << logMessage << endl;
+    LogWriter::logFile << logMessage << endl;
 
-    logFile.close();
+    LogWriter::logFile.close();
   }
 
+  static string logFileName;
+  static bool firstWriting;
+
+  static ofstream logFile;
+
 private:
-  string logFileName;
-  ofstream logFile;
-  bool firstWriting;
 };

--- a/DustRiders/DustRiders/Overlay.cpp
+++ b/DustRiders/DustRiders/Overlay.cpp
@@ -11,7 +11,7 @@ Overlay::Overlay()
 	lastTime = glfwGetTime();
 }
 
-void Overlay::RenderOverlay(StateHandler::GameState gameState, std::vector<Entity*> entities, EntityComponentSystem* ecs)
+void Overlay::RenderOverlay(StateHandler::GameState gameState, StateHandler::GameState prevGameState, std::vector<Entity *> entities, EntityComponentSystem *ecs)
 {
 	// Framerate calculations
 	double currentTime = glfwGetTime();
@@ -36,36 +36,27 @@ void Overlay::RenderOverlay(StateHandler::GameState gameState, std::vector<Entit
 	ImGui::SetNextWindowPos(ImVec2(5, 5));
 	// Setting flags
 	ImGuiWindowFlags textWindowFlags =
-		ImGuiWindowFlags_NoMove |						// text "window" should not move
-		ImGuiWindowFlags_NoResize |					// should not resize
-		ImGuiWindowFlags_NoCollapse |				// should not collapse
-		ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
-		ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
-		// ImGuiWindowFlags_NoBackground |		// window should be transparent; only the text should be visible
-		ImGuiWindowFlags_NoDecoration | // no decoration; only the text should be visible
-		ImGuiWindowFlags_NoTitleBar;		// no title; only the text should be visible
-// Begin a new window with these flags. (bool *)0 is the "default" value for its argument.
-	ImGui::Begin("DustRiders", (bool*)0, textWindowFlags);
+			ImGuiWindowFlags_NoMove |						// text "window" should not move
+			ImGuiWindowFlags_NoResize |					// should not resize
+			ImGuiWindowFlags_NoCollapse |				// should not collapse
+			ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
+			ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
+			// ImGuiWindowFlags_NoBackground |		// window should be transparent; only the text should be visible
+			ImGuiWindowFlags_NoDecoration | // no decoration; only the text should be visible
+			ImGuiWindowFlags_NoTitleBar;		// no title; only the text should be visible
+																			// Begin a new window with these flags. (bool *)0 is the "default" value for its argument.
+	ImGui::Begin("DustRiders", (bool *)0, textWindowFlags);
 	ImGui::Text("FPS: %i", currentFps);
-	switch (gameState)
+	ImGui::Text("Previous State: %s", std::string(prevGameState).c_str());
+	ImGui::Text("Current State: %s", std::string(gameState).c_str());
+	if (ImGui::CollapsingHeader("Entity Introspection"))
 	{
-	case StateHandler::GameState::StartMenu:
-		ImGui::Text("Press forward to start playing");
-		break;
-	case StateHandler::GameState::Playing:
-		ImGui::Text("Playing game");
-		break;
-	case StateHandler::GameState::PauseMenu:
-		ImGui::Text("Paused.");
-		break;
-
-	default:
-		break;
-	}
-	if (ImGui::CollapsingHeader("Entity Introspection")) {
-		if (ImGui::BeginCombo("Entities", &selectedEntity[0])) {
-			for (auto& entity : entities) {
-				if (ImGui::Selectable(&entity->name[0])) {
+		if (ImGui::BeginCombo("Entities", &selectedEntity[0]))
+		{
+			for (auto &entity : entities)
+			{
+				if (ImGui::Selectable(&entity->name[0]))
+				{
 					selectedEntity = entity->name;
 				}
 				ImGui::SetItemDefaultFocus();
@@ -76,7 +67,8 @@ void Overlay::RenderOverlay(StateHandler::GameState gameState, std::vector<Entit
 		if (!ecs->doesKeyExist(selectedEntity))
 			selectedEntity = "";
 
-		if (selectedEntity != "") {
+		if (selectedEntity != "")
+		{
 			ImGui::Text("X: %f", ecs->get(selectedEntity)->transform->position.x);
 			ImGui::Text("Y: %f", ecs->get(selectedEntity)->transform->position.y);
 			ImGui::Text("Z: %f", ecs->get(selectedEntity)->transform->position.z);
@@ -90,7 +82,8 @@ void Overlay::RenderOverlay(StateHandler::GameState gameState, std::vector<Entit
 
 	std::map<int, Joystick> tMap = JoystickHandler::getJSMap();
 
-	if (ImGui::CollapsingHeader("Controllers")) {
+	if (ImGui::CollapsingHeader("Controllers"))
+	{
 		ImGui::Text("NumJS: %d", tMap.size());
 
 		auto jsItr = tMap.begin();
@@ -104,7 +97,6 @@ void Overlay::RenderOverlay(StateHandler::GameState gameState, std::vector<Entit
 			jsItr++;
 		}
 	}
-
 
 	// End the window.
 	ImGui::End();
@@ -126,23 +118,23 @@ void Overlay::RenderPause(int windowHeight, int windowWidth)
 
 	// Setting flags
 	ImGuiWindowFlags textWindowFlags =
-		ImGuiWindowFlags_NoMove |						// text "window" should not move
-		ImGuiWindowFlags_NoResize |					// should not resize
-		ImGuiWindowFlags_NoCollapse |				// should not collapse
-		ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
-		ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
-		ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
-		ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
-		ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
+			ImGuiWindowFlags_NoMove |						// text "window" should not move
+			ImGuiWindowFlags_NoResize |					// should not resize
+			ImGuiWindowFlags_NoCollapse |				// should not collapse
+			ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
+			ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
+			ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
+			ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
+			ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.75, windowHeight / 2));
-	ImGui::Begin("DustRiderTitle", (bool*)0, textWindowFlags);
+	ImGui::Begin("DustRiderTitle", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 100.0f);
 	ImGui::Text("DustRiders");
 	ImGui::End();
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.7, windowHeight * 1.05));
-	ImGui::Begin("ScoreText", (bool*)0, textWindowFlags);
+	ImGui::Begin("ScoreText", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 180.0f);
 
 	if (isKeyboard)
@@ -159,7 +151,7 @@ void Overlay::RenderPause(int windowHeight, int windowWidth)
 	}
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.1, windowHeight * 1.4));
-	ImGui::Begin("ControlInput", (bool*)0, textWindowFlags);
+	ImGui::Begin("ControlInput", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 180.0f);
 	if (isKeyboard)
 	{
@@ -197,23 +189,23 @@ void Overlay::RenderMenu(int windowHeight, int windowWidth)
 
 	// Setting flags
 	ImGuiWindowFlags textWindowFlags =
-		ImGuiWindowFlags_NoMove |						// text "window" should not move
-		ImGuiWindowFlags_NoResize |					// should not resize
-		ImGuiWindowFlags_NoCollapse |				// should not collapse
-		ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
-		ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
-		ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
-		ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
-		ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
+			ImGuiWindowFlags_NoMove |						// text "window" should not move
+			ImGuiWindowFlags_NoResize |					// should not resize
+			ImGuiWindowFlags_NoCollapse |				// should not collapse
+			ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
+			ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
+			ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
+			ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
+			ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.75, windowHeight / 2));
-	ImGui::Begin("DustRiderTitle", (bool*)0, textWindowFlags);
+	ImGui::Begin("DustRiderTitle", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 100.0f);
 	ImGui::Text("DustRiders");
 	ImGui::End();
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.7, windowHeight * 1.05));
-	ImGui::Begin("ScoreText", (bool*)0, textWindowFlags);
+	ImGui::Begin("ScoreText", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 180.0f);
 
 	if (isKeyboard)
@@ -230,7 +222,7 @@ void Overlay::RenderMenu(int windowHeight, int windowWidth)
 	}
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.1, windowHeight * 1.4));
-	ImGui::Begin("ControlInput", (bool*)0, textWindowFlags);
+	ImGui::Begin("ControlInput", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 180.0f);
 	if (isKeyboard)
 	{
@@ -268,17 +260,17 @@ void Overlay::RenderWin(int windowHeight, int windowWidth)
 
 	// Setting flags
 	ImGuiWindowFlags textWindowFlags =
-		ImGuiWindowFlags_NoMove |						// text "window" should not move
-		ImGuiWindowFlags_NoResize |					// should not resize
-		ImGuiWindowFlags_NoCollapse |				// should not collapse
-		ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
-		ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
-		ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
-		ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
-		ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
+			ImGuiWindowFlags_NoMove |						// text "window" should not move
+			ImGuiWindowFlags_NoResize |					// should not resize
+			ImGuiWindowFlags_NoCollapse |				// should not collapse
+			ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
+			ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
+			ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
+			ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
+			ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.75, windowHeight / 2));
-	ImGui::Begin("DustRiderWin", (bool*)0, textWindowFlags);
+	ImGui::Begin("DustRiderWin", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 100.0f);
 	ImGui::Text("You Win!");
 	ImGui::End();
@@ -298,17 +290,17 @@ void Overlay::RenderLoss(int windowHeight, int windowWidth)
 
 	// Setting flags
 	ImGuiWindowFlags textWindowFlags =
-		ImGuiWindowFlags_NoMove |						// text "window" should not move
-		ImGuiWindowFlags_NoResize |					// should not resize
-		ImGuiWindowFlags_NoCollapse |				// should not collapse
-		ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
-		ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
-		ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
-		ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
-		ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
+			ImGuiWindowFlags_NoMove |						// text "window" should not move
+			ImGuiWindowFlags_NoResize |					// should not resize
+			ImGuiWindowFlags_NoCollapse |				// should not collapse
+			ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
+			ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
+			ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
+			ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
+			ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.75, windowHeight / 2));
-	ImGui::Begin("DustRiderLose", (bool*)0, textWindowFlags);
+	ImGui::Begin("DustRiderLose", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 100.0f);
 	ImGui::Text("You Lose!");
 	ImGui::End();

--- a/DustRiders/DustRiders/Overlay.cpp
+++ b/DustRiders/DustRiders/Overlay.cpp
@@ -107,7 +107,7 @@ void Overlay::RenderOverlay(StateHandler::GameState gameState, StateHandler::Gam
 	// End ImGui
 }
 
-void Overlay::RenderPause(int windowHeight, int windowWidth)
+void Overlay::RenderPause(StateHandler::GameState prevState, int windowHeight, int windowWidth)
 {
 	bool isKeyboard = JoystickHandler::getFirstJS().isPseudo();
 
@@ -137,16 +137,16 @@ void Overlay::RenderPause(int windowHeight, int windowWidth)
 	ImGui::Begin("ScoreText", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 180.0f);
 
-	if (isKeyboard)
+	if (prevState != StateHandler::GameState::Playing)
 	{
-		ImGui::Text("Press Enter to Resume Game");
-		ImGui::Text("Press Escape to Exit Game");
+		ImGui::Text("Press ENTER or A Button to start.");
+		ImGui::Text("Press X or X Button to quit DustRiders.");
 		ImGui::End();
 	}
 	else
 	{
-		ImGui::Text("Press START to Resume Game");
-		ImGui::Text("Press X to Exit");
+		ImGui::Text("Press ESC or START Button to resume playing.");
+		ImGui::Text("Press X or X Button to quit DustRiders.");
 		ImGui::End();
 	}
 
@@ -273,6 +273,15 @@ void Overlay::RenderWin(int windowHeight, int windowWidth)
 	ImGui::Begin("DustRiderWin", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 100.0f);
 	ImGui::Text("You Win!");
+
+	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.7, windowHeight * 1.2));
+	ImGui::Begin("ScoreText", (bool *)0, textWindowFlags);
+	ImGui::SetWindowFontScale(3.0f);
+
+	ImGui::Text("Press ENTER or A Button to Play Again");
+	ImGui::Text("Press X or X Button to quit DustRiders");
+	ImGui::End();
+
 	ImGui::End();
 
 	ImGui::Render(); // Render the ImGui window
@@ -303,6 +312,14 @@ void Overlay::RenderLoss(int windowHeight, int windowWidth)
 	ImGui::Begin("DustRiderLose", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 100.0f);
 	ImGui::Text("You Lose!");
+	ImGui::End();
+
+	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.7, windowHeight * 1.2));
+	ImGui::Begin("ScoreText", (bool *)0, textWindowFlags);
+	ImGui::SetWindowFontScale(3.0f);
+
+	ImGui::Text("Press ENTER or A Button to Play Again");
+	ImGui::Text("Press X or X Button to quit DustRiders");
 	ImGui::End();
 
 	ImGui::Render(); // Render the ImGui window

--- a/DustRiders/DustRiders/Overlay.cpp
+++ b/DustRiders/DustRiders/Overlay.cpp
@@ -11,6 +11,35 @@ Overlay::Overlay()
 	lastTime = glfwGetTime();
 }
 
+void Overlay::LoadingContent(int windowWidth, int windowHeight)
+{
+	ImGui_ImplOpenGL3_NewFrame();
+	ImGui_ImplGlfw_NewFrame();
+	ImGui::NewFrame();
+	// Putting the text-containing window in the top-left of the screen.
+
+	// Setting flags
+	ImGuiWindowFlags textWindowFlags =
+			ImGuiWindowFlags_NoMove |						// text "window" should not move
+			ImGuiWindowFlags_NoResize |					// should not resize
+			ImGuiWindowFlags_NoCollapse |				// should not collapse
+			ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
+			ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
+			ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
+			ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
+			ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
+
+	ImGui::SetNextWindowPos(ImVec2(windowWidth / 2, windowHeight / 2));
+	ImGui::Begin("DustRiderTitle", (bool *)0, textWindowFlags);
+	ImGui::SetWindowFontScale(2.0f);
+	ImGui::Text("Loading content...");
+	ImGui::End();
+
+	ImGui::Render(); // Render the ImGui window
+	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+	return;
+}
+
 void Overlay::RenderOverlay(StateHandler::GameState gameState, StateHandler::GameState prevGameState, std::vector<Entity *> entities, EntityComponentSystem *ecs)
 {
 	// Framerate calculations
@@ -193,8 +222,8 @@ void Overlay::RenderMenu(int windowHeight, int windowWidth)
 			ImGuiWindowFlags_NoResize |					// should not resize
 			ImGuiWindowFlags_NoCollapse |				// should not collapse
 			ImGuiWindowFlags_NoSavedSettings |	// don't want saved settings mucking things up
-			ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
 			ImGuiWindowFlags_NoBackground |			// window should be transparent; only the text should be visible
+			ImGuiWindowFlags_AlwaysAutoResize | // window should auto-resize to fit the text
 			ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
 			ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
 

--- a/DustRiders/DustRiders/Overlay.cpp
+++ b/DustRiders/DustRiders/Overlay.cpp
@@ -29,9 +29,9 @@ void Overlay::LoadingContent(int windowWidth, int windowHeight)
 			ImGuiWindowFlags_NoDecoration |			// no decoration; only the text should be visible
 			ImGuiWindowFlags_NoTitleBar;				// no title; only the text should be visible
 
-	ImGui::SetNextWindowPos(ImVec2(windowWidth / 2, windowHeight / 2));
+	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.77, windowHeight * 0.9));
 	ImGui::Begin("DustRiderTitle", (bool *)0, textWindowFlags);
-	ImGui::SetWindowFontScale(2.0f);
+	ImGui::SetWindowFontScale(windowHeight / 400.0f);
 	ImGui::Text("Loading content...");
 	ImGui::End();
 
@@ -92,9 +92,6 @@ void Overlay::RenderOverlay(StateHandler::GameState gameState, StateHandler::Gam
 			}
 			ImGui::EndCombo();
 		}
-
-		if (!ecs->doesKeyExist(selectedEntity))
-			selectedEntity = "";
 
 		if (selectedEntity != "")
 		{
@@ -158,13 +155,13 @@ void Overlay::RenderPause(StateHandler::GameState prevState, int windowHeight, i
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.75, windowHeight / 2));
 	ImGui::Begin("DustRiderTitle", (bool *)0, textWindowFlags);
-	ImGui::SetWindowFontScale(windowHeight / 100.0f);
+	ImGui::SetWindowFontScale(5.0f);
 	ImGui::Text("DustRiders");
 	ImGui::End();
 
-	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.7, windowHeight * 1.05));
+	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.9, windowHeight * 1.6));
 	ImGui::Begin("ScoreText", (bool *)0, textWindowFlags);
-	ImGui::SetWindowFontScale(windowHeight / 180.0f);
+	ImGui::SetWindowFontScale(3.0f);
 
 	if (prevState != StateHandler::GameState::Playing)
 	{
@@ -182,26 +179,13 @@ void Overlay::RenderPause(StateHandler::GameState prevState, int windowHeight, i
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.1, windowHeight * 1.4));
 	ImGui::Begin("ControlInput", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 180.0f);
-	if (isKeyboard)
-	{
-		ImGui::Text("W to Forward");
-		ImGui::Text("S to Backward");
-		ImGui::Text("A to Left");
-		ImGui::Text("D to Right");
-		ImGui::Text("Left Shift to Reverse");
-		ImGui::Text("Enter to Fire Weapon");
-		ImGui::Text("ESC to open menu");
-		ImGui::End();
-	}
-	else
-	{
-		ImGui::Text("RT to Accelerate");
-		ImGui::Text("LT to Brake");
-		ImGui::Text("LB to Reverse");
-		ImGui::Text("LJS to Steer");
-		ImGui::Text("START to toggle menu and pause");
-		ImGui::End();
-	}
+
+	ImGui::Text("RT to accerlate, LT to brake (Controller)");
+	ImGui::Text("Left JS to steer (Controller)");
+	ImGui::Text("WASD to Steer (Keyboard)");
+	ImGui::Text("Hold Left Shift or LB to Reverse");
+	ImGui::Text("ESC or START to toggle pause");
+	ImGui::End();
 
 	ImGui::Render(); // Render the ImGui window
 	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
@@ -209,7 +193,6 @@ void Overlay::RenderPause(StateHandler::GameState prevState, int windowHeight, i
 
 void Overlay::RenderMenu(int windowHeight, int windowWidth)
 {
-	bool isKeyboard = JoystickHandler::getFirstJS().isPseudo();
 
 	ImGui_ImplOpenGL3_NewFrame();
 	ImGui_ImplGlfw_NewFrame();
@@ -236,43 +219,19 @@ void Overlay::RenderMenu(int windowHeight, int windowWidth)
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.7, windowHeight * 1.05));
 	ImGui::Begin("ScoreText", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 180.0f);
-
-	if (isKeyboard)
-	{
-		ImGui::Text("Press Enter to Start Game");
-		ImGui::Text("Press Escape to Exit");
-		ImGui::End();
-	}
-	else
-	{
-		ImGui::Text("Press A to Start Game");
-		ImGui::Text("Press X to Exit");
-		ImGui::End();
-	}
+	ImGui::Text("Press ENTER or A Button to Start Game");
+	ImGui::Text("Press X or X Button to Exit");
+	ImGui::End();
 
 	ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.1, windowHeight * 1.4));
 	ImGui::Begin("ControlInput", (bool *)0, textWindowFlags);
 	ImGui::SetWindowFontScale(windowHeight / 180.0f);
-	if (isKeyboard)
-	{
-		ImGui::Text("W to Forward");
-		ImGui::Text("S to Backward");
-		ImGui::Text("A to Left");
-		ImGui::Text("D to Right");
-		ImGui::Text("Left Shift to Reverse");
-		ImGui::Text("Enter to Fire Weapon");
-		ImGui::Text("ESC to open menu");
-		ImGui::End();
-	}
-	else
-	{
-		ImGui::Text("RT to Accelerate");
-		ImGui::Text("LT to Brake");
-		ImGui::Text("LB to Reverse");
-		ImGui::Text("LJS to Steer");
-		ImGui::Text("START to toggle menu and pause");
-		ImGui::End();
-	}
+	ImGui::Text("RT to accerlate, LT to brake (Controller)");
+	ImGui::Text("Left JS to steer (Controller)");
+	ImGui::Text("WASD to Steer (Keyboard)");
+	ImGui::Text("Hold Left Shift or LB to Reverse");
+	ImGui::Text("ESC or START to toggle pause");
+	ImGui::End();
 
 	ImGui::Render(); // Render the ImGui window
 	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
@@ -280,7 +239,6 @@ void Overlay::RenderMenu(int windowHeight, int windowWidth)
 
 void Overlay::RenderWin(int windowHeight, int windowWidth)
 {
-	bool isKeyboard = JoystickHandler::getFirstJS().isPseudo();
 
 	ImGui_ImplOpenGL3_NewFrame();
 	ImGui_ImplGlfw_NewFrame();

--- a/DustRiders/DustRiders/Overlay.h
+++ b/DustRiders/DustRiders/Overlay.h
@@ -21,7 +21,7 @@ public:
 	Overlay();
 	void RenderOverlay(StateHandler::GameState, StateHandler::GameState, std::vector<Entity *>, EntityComponentSystem *);
 	void RenderMenu(int windowHeight, int windowWidth);
-	void RenderPause(int windowHeight, int windowWidth);
+	void RenderPause(StateHandler::GameState prevState, int windowHeight, int windowWidth);
 	void RenderWin(int windowHeight, int windowWidth);
 	void RenderLoss(int windowHeight, int windowWidth);
 	void Cleanup();

--- a/DustRiders/DustRiders/Overlay.h
+++ b/DustRiders/DustRiders/Overlay.h
@@ -19,6 +19,7 @@ private:
 
 public:
 	Overlay();
+	void LoadingContent(int windowWidth, int windowHeight);
 	void RenderOverlay(StateHandler::GameState, StateHandler::GameState, std::vector<Entity *>, EntityComponentSystem *);
 	void RenderMenu(int windowHeight, int windowWidth);
 	void RenderPause(StateHandler::GameState prevState, int windowHeight, int windowWidth);

--- a/DustRiders/DustRiders/Overlay.h
+++ b/DustRiders/DustRiders/Overlay.h
@@ -19,7 +19,7 @@ private:
 
 public:
 	Overlay();
-	void RenderOverlay(StateHandler::GameState, std::vector<Entity*>, EntityComponentSystem*);
+	void RenderOverlay(StateHandler::GameState, StateHandler::GameState, std::vector<Entity *>, EntityComponentSystem *);
 	void RenderMenu(int windowHeight, int windowWidth);
 	void RenderPause(int windowHeight, int windowWidth);
 	void RenderWin(int windowHeight, int windowWidth);

--- a/DustRiders/DustRiders/RenderingSystem.cpp
+++ b/DustRiders/DustRiders/RenderingSystem.cpp
@@ -160,37 +160,44 @@ void RenderingSystem::updateRender(std::vector<Entity *> &entityList, Camera &ca
 
 	glm::mat4 perspective = glm::perspective(glm::radians(45.0f), aspect, 0.01f, 1000.f);
 
-	for (Entity* entity : entityList)
+	int numRendered = 0;
+
+	for (Entity *entity : entityList)
 	{
-		ShaderProgram &shader = *entity->shaderProgram;
-		shader.use();
+		if (entity->shouldRender)
+		{
 
-		glm::mat4 model(1.0f);
-		model = glm::translate(model, entity->transform->position);
-		model = model * glm::toMat4(entity->transform->rotation);
-		model = glm::scale(model, entity->scale);
-		glm::vec3 lightPos = glm::vec3{200.0f, 2.0f, 200.0f};
-		glm::vec3 lightCol = glm::vec3(1.f, 1.f, 1.f);
+			ShaderProgram &shader = *entity->shaderProgram;
+			shader.use();
 
-		GLuint location = glGetUniformLocation(shader, "M");
-		glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(model));
+			glm::mat4 model(1.0f);
+			model = glm::translate(model, entity->transform->position);
+			model = model * glm::toMat4(entity->transform->rotation);
+			model = glm::scale(model, entity->scale);
+			glm::vec3 lightPos = glm::vec3{200.0f, 2.0f, 200.0f};
+			glm::vec3 lightCol = glm::vec3(1.f, 1.f, 1.f);
 
-		location = glGetUniformLocation(shader, "V");
-		glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(view));
+			GLuint location = glGetUniformLocation(shader, "M");
+			glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(model));
 
-		location = glGetUniformLocation(shader, "P");
-		glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(perspective));
+			location = glGetUniformLocation(shader, "V");
+			glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(view));
 
-		location = glGetUniformLocation(shader, "lightPos");
-		glUniform3fv(location, 1, glm::value_ptr(lightPos));
+			location = glGetUniformLocation(shader, "P");
+			glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(perspective));
 
-		location = glGetUniformLocation(shader, "lightCol");
-		glUniform3fv(location, 1, glm::value_ptr(lightCol));
+			location = glGetUniformLocation(shader, "lightPos");
+			glUniform3fv(location, 1, glm::value_ptr(lightPos));
 
-		location = glGetUniformLocation(shader, "cameraPos");
-		glUniform3fv(location, 1, glm::value_ptr(camPos));
+			location = glGetUniformLocation(shader, "lightCol");
+			glUniform3fv(location, 1, glm::value_ptr(lightCol));
 
-		entity->model->draw(shader, entity->useMatInt);
+			location = glGetUniformLocation(shader, "cameraPos");
+			glUniform3fv(location, 1, glm::value_ptr(camPos));
+
+			entity->model->draw(shader, entity->useMatInt);
+			numRendered++;
+		}
 	}
 
 	glDisable(GL_FRAMEBUFFER_SRGB); // disable sRGB for things like imgui

--- a/DustRiders/DustRiders/StateHandler.cpp
+++ b/DustRiders/DustRiders/StateHandler.cpp
@@ -46,6 +46,11 @@ void StateHandler::processJS(Joystick &js)
   }
   else if (gState > GameState::Playing) // Game has been won or lost
   {
+    if (pressed[Xbox::Button::XBOX_X])
+    {
+      setGState(GameState::Exit);
+      return;
+    }
     if (pressed[Xbox::Button::XBOX_A])
     {
       setRState(ReloadState::GameReset);

--- a/DustRiders/DustRiders/StateHandler.cpp
+++ b/DustRiders/DustRiders/StateHandler.cpp
@@ -23,13 +23,16 @@ void StateHandler::processJS(Joystick &js)
     return;
   }
 
-  if (gState == GameState::Playing || gState == GameState::NotStarted)
+  if (gState == GameState::Playing) // Game is currently being played
   {
     if (pressed[Xbox::Button::XBOX_MENU])
     {
       setGState(GameState::PauseMenu);
       if (js.isPseudo())
+      {
         js.releaseEsc();
+      }
+      return;
     }
     if (pressed[Xbox::Button::XBOX_UP])
     {
@@ -38,21 +41,50 @@ void StateHandler::processJS(Joystick &js)
       {
         js.releaseR();
       }
+      return;
     }
+  }
+  else if (gState > GameState::Playing) // Game has been won or lost
+  {
+    if (pressed[Xbox::Button::XBOX_A])
+    {
+      setRState(ReloadState::GameReset);
+      setGState(GameState::PauseMenu);
+      if (js.isPseudo())
+      {
+        js.releaseEnter();
+      }
+    }
+    return;
   }
   else if (gState == GameState::PauseMenu)
   {
-    if (pressed[Xbox::Button::XBOX_MENU])
-    {
-      setGState(prevGState);
-      if (js.isPseudo())
-        js.releaseEsc();
-      return;
-    }
     if (pressed[Xbox::Button::XBOX_X])
     {
       setGState(GameState::Exit);
       return;
+    }
+    if (prevGState == GameState::GameLost || prevGState == GameState::GameWon || prevGState == GameState::PauseMenu)
+    {
+      if (pressed[Xbox::Button::XBOX_A])
+      {
+        setGState(GameState::Playing);
+        if (js.isPseudo())
+        {
+          js.releaseEnter();
+        }
+      }
+      return;
+    }
+    else
+    {
+      if (pressed[Xbox::Button::XBOX_MENU])
+      {
+        setGState(prevGState);
+        if (js.isPseudo())
+          js.releaseEsc();
+        return;
+      }
     }
   }
   // To be used when the game first starts, with the overlay menu
@@ -110,8 +142,15 @@ StateHandler::GameState::operator std::string()
   case PauseMenu:
     stateString = "Pause Menu";
     break;
+  case GameWon:
+    stateString = "Game Won";
+    break;
+  case GameLost:
+    stateString = "Game Lost";
+    break;
   default:
     stateString = "Unknown";
+    break;
   }
   return stateString;
 }

--- a/DustRiders/DustRiders/StateHandler.h
+++ b/DustRiders/DustRiders/StateHandler.h
@@ -13,15 +13,22 @@ public:
   class GameState
   {
   public:
+    /**
+     * @brief States where the game is active are greater than 0.
+     * States where the game is inactive (pause, won, lost, etc),
+     * are less than 0
+     *
+     */
     enum State
     {
+      StartMenu = -3,
+      PauseMenu = -2,
       Exit = -1,
       NotStarted = 0,
       Playing = 1,
-      StartMenu = 2,
-      PauseMenu = 3,
-      GameWon = 4,
-      GameLost = 5
+      GameWon = 2,
+      GameLost = 3,
+
     };
 
     operator int() { return static_cast<int>(this->state); }

--- a/DustRiders/DustRiders/Vehicle.cpp
+++ b/DustRiders/DustRiders/Vehicle.cpp
@@ -94,6 +94,9 @@ bool Vehicle::initVehicle(PxVec3 p)
 		shape->setFlag(physx::PxShapeFlag::eTRIGGER_SHAPE, true);
 	}
 
+	initialFlags = gVehicle.mPhysXState.physxActor.rigidBody->getRigidBodyFlags();
+	initialActorFlags = gVehicle.mPhysXState.physxActor.rigidBody->getActorFlags();
+
 	return true;
 }
 
@@ -209,6 +212,8 @@ void Vehicle::reloadTuning()
 
 void Vehicle::reset()
 {
+	shouldRender = true; // Allow rendering to screen
+
 	initMaterialFrictionTable();
 
 	// Load the params from json or set directly.
@@ -223,9 +228,6 @@ void Vehicle::reset()
 	PxTransform pose(initPos, PxQuat(PxIdentity));
 	gVehicle.setUpActor(*gScene, pose, gVehicleName);
 
-	// Get existing flags for the rigid body
-	auto initFlags = gVehicle.mPhysXState.physxActor.rigidBody->getRigidBodyFlags();
-
 	// Set the body to be kinematic (has to be manually moved)
 	gVehicle.mPhysXState.physxActor.rigidBody->setRigidBodyFlag(PxRigidBodyFlag::eKINEMATIC, true);
 
@@ -236,5 +238,15 @@ void Vehicle::reset()
 	gVehicle.mBaseState.rigidBodyState.previousAngularVelocity = PxVec3(0.f, 0.f, 0.f);
 
 	// Restore previous rigid body flags
-	gVehicle.mPhysXState.physxActor.rigidBody->setRigidBodyFlags(initFlags);
+	gVehicle.mPhysXState.physxActor.rigidBody->setRigidBodyFlags(initialFlags);
+}
+
+void Vehicle::suspend()
+{
+	shouldRender = false; // Don't allow rendering to screen
+}
+
+void Vehicle::restore()
+{
+	shouldRender = true; // Allow rendering to screen
 }

--- a/DustRiders/DustRiders/Vehicle.cpp
+++ b/DustRiders/DustRiders/Vehicle.cpp
@@ -36,7 +36,7 @@ void Vehicle::initMaterialFrictionTable()
 	// If a material is encountered that is not mapped to a friction value, the friction value used is the specified default value.
 	// In this snippet there is only a single material so there can only be a single mapping between material and friction.
 	// In this snippet the same mapping is used by all tires.
-	gPhysXMaterialFrictions[0].friction = 1.0f;
+	gPhysXMaterialFrictions[0].friction = 2.0f;
 	gPhysXMaterialFrictions[0].material = this->gMaterial;
 	gPhysXDefaultMaterialFriction = 1.0f;
 	gNbPhysXMaterialFrictions = 1;

--- a/DustRiders/DustRiders/Vehicle.h
+++ b/DustRiders/DustRiders/Vehicle.h
@@ -48,6 +48,8 @@ public:
 	void reloadTuning();
 
 	void reset();
+	void suspend();
+	void restore();
 
 protected:
 	bool initVehicle(PxVec3);
@@ -78,6 +80,9 @@ protected:
 	PxVehiclePhysXMaterialFriction gPhysXMaterialFrictions[16];
 	PxU32 gNbPhysXMaterialFrictions = 1;
 	PxReal gPhysXDefaultMaterialFriction = 1.0f;
+
+	PxRigidBodyFlags initialFlags;
+	PxActorFlags initialActorFlags;
 
 	PxVec3 initPos;
 };

--- a/DustRiders/DustRiders/main.cpp
+++ b/DustRiders/DustRiders/main.cpp
@@ -195,7 +195,7 @@ int main()
 					{
 					case StateHandler::GameState::PauseMenu:
 						deltaT = 0.0f;
-						overlay.RenderMenu(windowHeight / 2, windowWidth / 2);
+						overlay.RenderPause(stateHandle.getPrevGState(), windowHeight / 2, windowWidth / 2);
 						break;
 					case StateHandler::GameState::GameWon:
 						deltaT = 0.0f;

--- a/DustRiders/DustRiders/media/vehicledata/Base.json
+++ b/DustRiders/DustRiders/media/vehicledata/Base.json
@@ -22,7 +22,7 @@
         "Scale": 1.0
     },
     "RigidBodyParams": {
-        "Mass": 2014.4000244140625,
+        "Mass": 1200.4000244140625,
         "MOI": [
             3200.0,
             3414.0,
@@ -34,21 +34,21 @@
         "WheelResponseMultipliers": [
             1.0,
             1.0,
-			1.0,
-			1.0
+            1.0,
+            1.0
         ]
     },
     "HandbrakeCommandResponseParams": {
         "MaxResponse": 0.0,
         "WheelResponseMultipliers": [
             0.0,
-			0.0,
+            0.0,
             1.0,
-			1.0
+            1.0
         ]
     },
     "SteerCommandResponseParams": {
-        "MaxResponse": 0.5235990285873413,
+        "MaxResponse": 0.75,
         "WheelResponseMultipliers": [
             1.0,
             1.0,
@@ -57,13 +57,13 @@
         ]
     },
     "AckermannParams": {
-		"WheelIds": [
-			0,
-			1
-		],
-		"WheelBase": 2.863219976425171,
-		"TrackWidth": 1.5510799884796143,
-		"Strength": 1.0
+        "WheelIds": [
+            0,
+            1
+        ],
+        "WheelBase": 2.863219976425171,
+        "TrackWidth": 1.5510799884796143,
+        "Strength": 1.0
     },
     "SuspensionParams": [
         {
@@ -207,7 +207,7 @@
             }
         }
     ],
-    "SuspensionStateCalculationParams":  {
+    "SuspensionStateCalculationParams": {
         "JounceCalculationType": 1,
         "LimitSuspensionExpansionVelocity": false
     },
@@ -229,17 +229,21 @@
             "SuspForceAppPoint": [
                 [
                     0.0,
-                    0.0, 0.0, -0.11204999685287476
+                    0.0,
+                    0.0,
+                    -0.11204999685287476
                 ]
             ],
             "TireForceAppPoint": [
                 [
                     0.0,
-                    0.0, 0.0, -0.11204999685287476
+                    0.0,
+                    0.0,
+                    -0.11204999685287476
                 ]
             ]
-		},
-		{
+        },
+        {
             "WheelId": 1,
             "WheelToeAngle": [
                 [
@@ -256,17 +260,21 @@
             "SuspForceAppPoint": [
                 [
                     0.0,
-                    0.0, 0.0, -0.11204999685287476
+                    0.0,
+                    0.0,
+                    -0.11204999685287476
                 ]
             ],
             "TireForceAppPoint": [
                 [
                     0.0,
-                    0.0, 0.0, -0.11204999685287476
+                    0.0,
+                    0.0,
+                    -0.11204999685287476
                 ]
-            ]			
+            ]
         },
-		{
+        {
             "WheelId": 2,
             "WheelToeAngle": [
                 [
@@ -283,17 +291,21 @@
             "SuspForceAppPoint": [
                 [
                     0.0,
-                    0.0, 0.0, -0.11204999685287476
+                    0.0,
+                    0.0,
+                    -0.11204999685287476
                 ]
             ],
             "TireForceAppPoint": [
                 [
                     0.0,
-                    0.0, 0.0, -0.11204999685287476
+                    0.0,
+                    0.0,
+                    -0.11204999685287476
                 ]
             ]
-		},
-		{
+        },
+        {
             "WheelId": 3,
             "WheelToeAngle": [
                 [
@@ -310,17 +322,21 @@
             "SuspForceAppPoint": [
                 [
                     0.0,
-                    0.0, 0.0, -0.11204999685287476
+                    0.0,
+                    0.0,
+                    -0.11204999685287476
                 ]
             ],
             "TireForceAppPoint": [
                 [
                     0.0,
-                    0.0, 0.0, -0.11204999685287476
+                    0.0,
+                    0.0,
+                    -0.11204999685287476
                 ]
-            ]			
-        }		
-	],
+            ]
+        }
+    ],
     "SuspensionForceParams": [
         {
             "WheelId": 0,

--- a/DustRiders/DustRiders/media/vehicledata/DirectDrive.json
+++ b/DustRiders/DustRiders/media/vehicledata/DirectDrive.json
@@ -1,14 +1,98 @@
 {
-    "ThrottleCommandResponseParams": 
-	{
-        "MaxResponse": 750.0,
-        "WheelResponseMultipliers": [1.0, 1.0, 1.0, 1.0],
+	"ThrottleCommandResponseParams": {
+		"MaxResponse": 2000.0,
+		"WheelResponseMultipliers": [
+			1.0,
+			1.0,
+			1.0,
+			1.0
+		],
 		"NonLinearResponse": [
-			{"Throttle": 0.00, "ResponseCurve": [[0.0,0.00], [20.0, 0.00], [60.0, 0.0]]},
-			{"Throttle": 0.25, "ResponseCurve": [[0.0,0.25], [20.0, 0.25], [60.0, 0.0]]},
-			{"Throttle": 0.50, "ResponseCurve": [[0.0,0.50], [20.0, 0.50], [60.0, 0.0]]},
-			{"Throttle": 0.75, "ResponseCurve": [[0.0,0.75], [20.0, 0.75], [60.0, 0.0]]},
-			{"Throttle": 1.00, "ResponseCurve": [[1.0,1.00], [20.0, 1.00], [60.0, 0.0]]}			
+			{
+				"Throttle": 0.00,
+				"ResponseCurve": [
+					[
+						0.0,
+						0.00
+					],
+					[
+						20.0,
+						0.00
+					],
+					[
+						60.0,
+						0.0
+					]
+				]
+			},
+			{
+				"Throttle": 0.25,
+				"ResponseCurve": [
+					[
+						0.0,
+						0.25
+					],
+					[
+						20.0,
+						0.25
+					],
+					[
+						60.0,
+						0.0
+					]
+				]
+			},
+			{
+				"Throttle": 0.50,
+				"ResponseCurve": [
+					[
+						0.0,
+						0.50
+					],
+					[
+						20.0,
+						0.50
+					],
+					[
+						60.0,
+						0.0
+					]
+				]
+			},
+			{
+				"Throttle": 0.75,
+				"ResponseCurve": [
+					[
+						0.0,
+						0.75
+					],
+					[
+						20.0,
+						0.75
+					],
+					[
+						60.0,
+						0.0
+					]
+				]
+			},
+			{
+				"Throttle": 1.00,
+				"ResponseCurve": [
+					[
+						1.0,
+						1.00
+					],
+					[
+						20.0,
+						1.00
+					],
+					[
+						60.0,
+						0.0
+					]
+				]
+			}
 		]
-    }
+	}
 }


### PR DESCRIPTION
- Players can now cycle through all states of the game without getting stuck
- Players can quit the game at any point without needing to alt+tab out of the game 
- Game no longer gets stuck at "Game Won" or "Game Lost" 
- Entities do not fail to reappear after resetting the game
- "Content Loading" Screen appears while assets are being loaded into the game before the main loop
- Corrected driving parameters to make racing the AI less frustrating
    - AI's speed was reduced by 0.2
    - All cars now have twice the amount of friction
    - All cars can now turn more sharply
    - Car mass was reduced to 1200kg
    - Car steering threshold was increased to 2000.0
    - Cars still drift, but less uncontrollably
    - Acceleration is more easily visible to the player

> "I kind of got sucked into it" - alpha tester